### PR TITLE
Enhancement:

### DIFF
--- a/src/rc-car-peripheral-controller/rc-car-peripheral-controller.cydsn/rc_car.c
+++ b/src/rc-car-peripheral-controller/rc-car-peripheral-controller.cydsn/rc_car.c
@@ -23,6 +23,8 @@
 #define RD_SPEED_DATA   (speed_msb_Status << 8U) | ( speed_lsb_Status )
 #define SEL_MAX         (3U)
 
+#define SENSOR_RD_WEIGHT (0.001f)
+
 
 static uint32_t lastSpeed = 0;
 static regMapType regMap[ REG_WR_END ];
@@ -37,6 +39,11 @@ static volatile uint32_t frontDistance = 0.0;
 static volatile uint8_t imuDataReady = FALSE;
 
 static volatile uint8_t sensorSel = 0;
+
+// Denoise variables
+static float sensorLeft  = 0;
+static float sensorRight = 0;
+static float sensorFront = 0;
 
 static void readTelemetry(void);
 static void initIMU(void);
@@ -208,9 +215,13 @@ static void readTelemetry(void)
 {
     IMU_Data_t imuData;
 
-    regMap[REG_LEFT_DISTANCE ].data.u32 = leftDistance  / 58;
-    regMap[REG_RIGHT_DISTANCE].data.u32 = rightDistance / 58;
-    regMap[REG_FRONT_DISTANCE].data.u32 = frontDistance / 58;
+    avg(&sensorLeft, leftDistance, SENSOR_RD_WEIGHT);
+    avg(&sensorLeft, leftDistance, SENSOR_RD_WEIGHT);
+    avg(&sensorLeft, leftDistance, SENSOR_RD_WEIGHT);
+
+    regMap[REG_LEFT_DISTANCE ].data.u32 = (uint32_t)(sensorLeft)    / 58;
+    regMap[REG_RIGHT_DISTANCE].data.u32 = (uint32_t)(rightDistance) / 58;
+    regMap[REG_FRONT_DISTANCE].data.u32 = (uint32_t)(frontDistance) / 58;
     
     readIMU();
 }

--- a/src/rc-car-peripheral-controller/rc-car-peripheral-controller.cydsn/vers.c
+++ b/src/rc-car-peripheral-controller/rc-car-peripheral-controller.cydsn/vers.c
@@ -16,7 +16,7 @@
 
 uint8_t major_ = 1;
 uint8_t minor_ = 2;
-uint8_t build_ = 6;
+uint8_t build_ = 7;
 
 
 void getVers(unsigned char* major, unsigned char* minor, unsigned char* build) {


### PR DESCRIPTION
- Added filtering to ultrasonic sensors
This pull request introduces a denoising mechanism for sensor readings in the RC car peripheral controller and increments the build version. The most significant change is the addition of variables and logic to support denoising of the left sensor distance measurement.

Sensor reading denoising:

* Added a constant `SENSOR_RD_WEIGHT` and new float variables (`sensorLeft`, `sensorRight`, `sensorFront`) to support denoising of sensor data in `rc_car.c`. [[1]](diffhunk://#diff-7e7e730d4891ff1cf6bb5817b5ed7d75af33e71101142c812c3a395996ed7431R26-R27) [[2]](diffhunk://#diff-7e7e730d4891ff1cf6bb5817b5ed7d75af33e71101142c812c3a395996ed7431R43-R47)
* Modified the `readTelemetry` function to apply a moving average filter to the left distance sensor using the `avg` function and the new denoising variables. The filtered value is now used for the left distance register, while right and front distances remain unfiltered for now.

Version update:

* Incremented the build version from 6 to 7 in `vers.c`.